### PR TITLE
Add import block sorting to scalafix

### DIFF
--- a/src/main/g8/.scalafix.conf
+++ b/src/main/g8/.scalafix.conf
@@ -1,4 +1,12 @@
 rules = [
   ProcedureSyntax,
-  RemoveUnused
+  RemoveUnused,
+  SortImports
+]
+
+SortImports.blocks = [
+  "$organization$",
+  "*",
+  "scala.",
+  "java.",
 ]

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -59,6 +59,10 @@ val tapirOpenAPICirceYAML = "com.softwaremill.tapir" %% "tapir-openapi-circe-yam
 val tapirOpenAPIDocs = "com.softwaremill.tapir" %% "tapir-openapi-docs" % TapirVersion
 val tapirSwaggerUIHttp4s = "com.softwaremill.tapir" %% "tapir-swagger-ui-http4s" % TapirVersion
 
+// Enable a basic import sorter -- rules are defined in .scalafix.conf
+scalafixDependencies in ThisBuild +=
+  "com.nequissimus" %% "sort-imports" % "0.3.2"
+
 lazy val settings = Seq(
   organization := "$organization$",
   name := "$name;format="norm"$",


### PR DESCRIPTION
Overview
-----

This PR adds a scalafix rule for import sorting that sorts imports into blocks. The blocks are ordered:

- within organization deps
- third party libs
- scala
- java

However, there's no `scalafixOnCompile` setting, so you still have to apply it manually. That will be much smaller if projects start with it.

Notes
-----

Because it causes a diff from the first thing you create, I'll make those changes and commit them post-testing that shows what it does.

Testing
-----

- `sbt new azavea/azavea.g8 --branch feature/js/scalafix-and-fmt-rules`
- defaults are fine
- `cd` to your new project, `git init`, `git add *`, `git commit -m 'first commit'`
- `sbt scalafix`
- examine your [heartbreakingly beautiful](https://twitter.com/variety/status/1195450147666350080?lang=en) sorted and grouped imports