### PR TITLE
Update PostgreSQL (12) and PostGIS (3)

### DIFF
--- a/src/main/g8/docker-compose.yml
+++ b/src/main/g8/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   database:
-    image: quay.io/azavea/postgis:3-postgres12.2-slim
+    image: quay.io/azavea/postgis:3-postgres12.4-slim
     environment:
       - POSTGRES_USER=$name;format="norm"$
       - POSTGRES_PASSWORD=$name;format="norm"$

--- a/src/main/g8/docker-compose.yml
+++ b/src/main/g8/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   database:
-    image: quay.io/azavea/postgis:2.3-postgres9.6-slim
+    image: quay.io/azavea/postgis:3-postgres12.2-slim
     environment:
       - POSTGRES_USER=$name;format="norm"$
       - POSTGRES_PASSWORD=$name;format="norm"$


### PR DESCRIPTION
These are the most current versions of PostgreSQL and PostGIS that align with versions available via Amazon RDS.