### PR TITLE
Include system environment in application command parse

### DIFF
--- a/src/main/g8/application/src/main/scala/$package__packaged$/api/Server.scala
+++ b/src/main/g8/application/src/main/scala/$package__packaged$/api/Server.scala
@@ -56,7 +56,7 @@ object Server extends IOApp {
   override def run(args: List[String]): IO[ExitCode] = {
     import Commands._
 
-    applicationCommand.parse(args) map {
+    applicationCommand.parse(args, env = sys.env) map {
       case RunServer(apiConfig, dbConfig) =>
         createServer(apiConfig, dbConfig)
           .use(_ => IO.never)

--- a/src/main/g8/application/src/main/scala/$package__packaged$/api/commands/ApiOptions.scala
+++ b/src/main/g8/application/src/main/scala/$package__packaged$/api/commands/ApiOptions.scala
@@ -7,28 +7,30 @@ import com.monovore.decline.refined._
 
 trait ApiOptions {
 
-  private val externalPort = Opts
-    .option[PosInt]("external-port",
-                    help = "Port users/clients hit for requests")
+  private val externalPortHelp = "Port users/clients hit for requests"
+  private val externalPort = (Opts
+    .option[PosInt]("external-port", help = externalPortHelp)
+    .orElse Opts.env[PosInt]("API_EXTERNAL_PORT", help = externalPortHelp))
     .withDefault(PosInt($default_api_port$))
 
-  private val internalPort = Opts
-    .option[PosInt](
-      "internal-port",
-      help =
-        "Port server listens on, this will be different from 'external-port' when service is started behind a proxy"
-    )
+  private val internalPortHelp =
+    "Port server listens on, this will be different from 'external-port' when service is started behind a proxy"
+  private val internalPort = (Opts
+    .option[PosInt]("internal-port", help = internalPortHelp)
+    .orElse Opts.env[PosInt]("API_INTERNAL_PORT", help = internalPortHelp))
     .withDefault(PosInt($default_api_port$))
 
-  private val apiHost = Opts
-    .option[String]("api-host",
-                    help = "Hostname $name$ is hosted it (e.g. localhost)")
+  private val apiHostHelp = "Hostname $name$ is hosted it (e.g. localhost)"
+  private val apiHost = (Opts
+    .option[String]("api-host", help = apiHostHelp)
+    .orElse Opts.env[String]("API_HOST", help = apiHostHelp))
     .withDefault("localhost")
 
+  private val apiSchemeHelp = "Scheme server is exposed to end users with"
   private val apiScheme =
-    Opts
-      .option[String]("api-scheme",
-                      "Scheme server is exposed to end users with")
+    (Opts
+      .option[String]("api-scheme", help = apiSchemeHelp)
+      .orElse Opts.env[String]("API_SCHEME", help = apiSchemeHelp))
       .withDefault("http")
       .validate("Scheme must be either 'http' or 'https'")(s =>
         (s == "http" || s == "https"))

--- a/src/main/g8/application/src/main/scala/$package__packaged$/api/commands/ApiOptions.scala
+++ b/src/main/g8/application/src/main/scala/$package__packaged$/api/commands/ApiOptions.scala
@@ -10,33 +10,32 @@ trait ApiOptions {
   private val externalPortHelp = "Port users/clients hit for requests"
   private val externalPort = (Opts
     .option[PosInt]("external-port", help = externalPortHelp)
-    .orElse Opts.env[PosInt]("API_EXTERNAL_PORT", help = externalPortHelp))
+    .orElse(Opts.env[PosInt]("API_EXTERNAL_PORT", help = externalPortHelp)))
     .withDefault(PosInt($default_api_port$))
 
   private val internalPortHelp =
     "Port server listens on, this will be different from 'external-port' when service is started behind a proxy"
   private val internalPort = (Opts
     .option[PosInt]("internal-port", help = internalPortHelp)
-    .orElse Opts.env[PosInt]("API_INTERNAL_PORT", help = internalPortHelp))
+    .orElse(Opts.env[PosInt]("API_INTERNAL_PORT", help = internalPortHelp)))
     .withDefault(PosInt($default_api_port$))
 
   private val apiHostHelp = "Hostname $name$ is hosted it (e.g. localhost)"
   private val apiHost = (Opts
     .option[String]("api-host", help = apiHostHelp)
-    .orElse Opts.env[String]("API_HOST", help = apiHostHelp))
+    .orElse(Opts.env[String]("API_HOST", help = apiHostHelp)))
     .withDefault("localhost")
 
   private val apiSchemeHelp = "Scheme server is exposed to end users with"
   private val apiScheme =
     (Opts
       .option[String]("api-scheme", help = apiSchemeHelp)
-      .orElse Opts.env[String]("API_SCHEME", help = apiSchemeHelp))
+      .orElse(Opts.env[String]("API_SCHEME", help = apiSchemeHelp)))
       .withDefault("http")
       .validate("Scheme must be either 'http' or 'https'")(s =>
-        (s == "http" || s == "https"))
+        (s == "http" || s == "https")
+      )
 
-  val apiConfig: Opts[ApiConfig] = (externalPort,
-                                    internalPort,
-                                    apiHost,
-                                    apiScheme) mapN ApiConfig
+  val apiConfig: Opts[ApiConfig] =
+    (externalPort, internalPort, apiHost, apiScheme) mapN ApiConfig
 }

--- a/src/main/g8/application/src/main/scala/$package__packaged$/api/commands/DatabaseOptions.scala
+++ b/src/main/g8/application/src/main/scala/$package__packaged$/api/commands/DatabaseOptions.scala
@@ -15,24 +15,34 @@ import scala.util.Try
 
 trait DatabaseOptions {
 
-  private val databasePort = Opts
-    .option[PosInt]("db-port", help = "Port to connect to database on")
+  private val databasePortHelp = "Port to connect to database on"
+  private val databasePort = (Opts
+    .option[PosInt]("db-port", help = databasePortHelp)
+    .orElse Opts.env[PosInt]("POSTGRES_PORT", help=databasePortHelp))
     .withDefault(PosInt($default_db_port$))
 
-  private val databaseHost = Opts
-    .option[String]("db-host", help = "Database host to connect to")
+  private val databaseHostHelp = "Database host to connect to"
+  private val databaseHost = (Opts
+    .option[String]("db-host", help = databaseHostHelp)
+    .orElse Opts.env[String]("POSTGRES_HOST", help=databaseHostHelp))
     .withDefault("localhost")
 
-  private val databaseName = Opts
-    .option[String]("db-name", help = "Database name to connect to")
+  private val databaseNameHelp = "Database name to connect to"
+  private val databaseName = (Opts
+    .option[String]("db-name", help = databaseNameHelp)
+    .orElse Opts.env[String]("POSTGRES_NAME", help = databaseNameHelp))
     .withDefault("$name;format="norm"$")
 
-  private val databasePassword = Opts
-    .option[String]("db-password", help = "Database password to use")
+  private val databasePasswordHelp = "Database password to use"
+  private val databasePassword = (Opts
+    .option[String]("db-password", help = databasePasswordHelp)
+    .orElse Opts.env[String]("POSTGRES_PASSWORD", help = databasePasswordHelp))
     .withDefault("$name;format="norm"$")
 
-  private val databaseUser = Opts
-    .option[String]("db-user", help = "User to connect with database with")
+  private val databaseUserHelp = "User to connect with database with"
+  private val databaseUser = (Opts
+    .option[String]("db-user", help = databaseUserHelp)
+    .orElse Opts.env[String]("POSTGRES_USER", help = databaseUserHelp))
     .withDefault("$name;format="norm"$")
 
   def databaseConfig(

--- a/src/main/g8/application/src/main/scala/$package__packaged$/api/commands/DatabaseOptions.scala
+++ b/src/main/g8/application/src/main/scala/$package__packaged$/api/commands/DatabaseOptions.scala
@@ -18,31 +18,31 @@ trait DatabaseOptions {
   private val databasePortHelp = "Port to connect to database on"
   private val databasePort = (Opts
     .option[PosInt]("db-port", help = databasePortHelp)
-    .orElse Opts.env[PosInt]("POSTGRES_PORT", help=databasePortHelp))
+    .orElse(Opts.env[PosInt]("POSTGRES_PORT", help=databasePortHelp)))
     .withDefault(PosInt($default_db_port$))
 
   private val databaseHostHelp = "Database host to connect to"
   private val databaseHost = (Opts
     .option[String]("db-host", help = databaseHostHelp)
-    .orElse Opts.env[String]("POSTGRES_HOST", help=databaseHostHelp))
+    .orElse(Opts.env[String]("POSTGRES_HOST", help=databaseHostHelp)))
     .withDefault("localhost")
 
   private val databaseNameHelp = "Database name to connect to"
   private val databaseName = (Opts
     .option[String]("db-name", help = databaseNameHelp)
-    .orElse Opts.env[String]("POSTGRES_NAME", help = databaseNameHelp))
+    .orElse(Opts.env[String]("POSTGRES_NAME", help = databaseNameHelp)))
     .withDefault("$name;format="norm"$")
 
   private val databasePasswordHelp = "Database password to use"
   private val databasePassword = (Opts
     .option[String]("db-password", help = databasePasswordHelp)
-    .orElse Opts.env[String]("POSTGRES_PASSWORD", help = databasePasswordHelp))
+    .orElse(Opts.env[String]("POSTGRES_PASSWORD", help = databasePasswordHelp)))
     .withDefault("$name;format="norm"$")
 
   private val databaseUserHelp = "User to connect with database with"
   private val databaseUser = (Opts
     .option[String]("db-user", help = databaseUserHelp)
-    .orElse Opts.env[String]("POSTGRES_USER", help = databaseUserHelp))
+    .orElse(Opts.env[String]("POSTGRES_USER", help = databaseUserHelp)))
     .withDefault("$name;format="norm"$")
 
   def databaseConfig(


### PR DESCRIPTION
Overview
-----

This PR backports work from azavea/franklin#398 and raster-foundry/granary#425 to parse environment variables at server startup time.

Testing
-----

- start a new project from this template -- `g8 file:///abs path to this repo` and accept all the defaults
- export an environment variable for one of the configuration keys, e.g., `export API_SCHEME=httplol`
- `cd quickstart`
- `sbt bloopInstall`
- `./scripts/server` -- it should fail because `httplol` is not a valid scheme, which lets you know it's respecting the environment config

Closes #19