### PR TITLE
Explicitly include test file in STRTA

### DIFF
--- a/.g8ignore
+++ b/.g8ignore
@@ -1,0 +1,3 @@
+# Files named `test` are ignored by default, this explicitly includes it.
+# See https://github.com/foundweekends/giter8/issues/221
+!scripts/test


### PR DESCRIPTION
## Overview

After templating a new project, I noticed that `scripts/test` was missing from the scaffolded project. Turns out, g8 [ignores files named `test`](https://github.com/foundweekends/giter8/issues/221) by default! A full list of defaults is available [here](https://github.com/foundweekends/giter8/blob/64e651932aed5a376ccea4cf9832fb257361f9c5/library/src/main/scala/g8.scala#L280-L298).

This was addressed with the introduction of the `.g8ignore` file, which declares files to be excluded from the templated project. By declaring a negation rule for `scripts/test`, we override the default and include the file.

This regression was introduced in #10.

## Testing Instructions

- Run `sbt new azavea/azavea.g8` and accept the defaults.
- Run `ls quickstart/scripts`. `test` will be missing.
- Remove the `quickstart` project with `rm -rf quickstart`.
- From this PR branch, recreate the scaffold with `sbt new file:///path/to/local/azavea.g8`.
- Run `ls quickstart/scripts`. `test` should be present.