### PR TITLE
Use organize-imports to check import ordering

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -39,7 +39,7 @@ jobs:
             --package=com.azavea.ci \
             --default-api-port=8080 \
             --default-db-port=5432
-          cd ci && sbt ";bloopInstall; scalafmt; scalafmtSbt"
+          cd ci && sbt ";bloopInstall; scalafmt; scalafmtSbt; scalafix --check"
   merge-dependabot:
     needs:
       - build

--- a/src/main/g8/.scalafix.conf
+++ b/src/main/g8/.scalafix.conf
@@ -4,9 +4,12 @@ rules = [
   OrganizeImports
 ]
 
-OrganizeImports.groups = [
-  "$organization$",
-  "*",
-  "scala.",
-  "java.",
-]
+OrganizeImports {
+  groupedImports = Merge
+  groups = [
+    "$organization$",
+    "*",
+    "scala.",
+    "java.",
+  ]
+}

--- a/src/main/g8/.scalafix.conf
+++ b/src/main/g8/.scalafix.conf
@@ -11,4 +11,5 @@ OrganizeImports {
     "scala.",
     "java.",
   ]
+  importSelectorsOrder = SymbolsFirst
 }

--- a/src/main/g8/.scalafix.conf
+++ b/src/main/g8/.scalafix.conf
@@ -1,10 +1,10 @@
 rules = [
   ProcedureSyntax,
   RemoveUnused,
-  SortImports
+  OrganizeImports
 ]
 
-SortImports.blocks = [
+OrganizeImports.groups = [
   "$organization$",
   "*",
   "scala.",

--- a/src/main/g8/.scalafix.conf
+++ b/src/main/g8/.scalafix.conf
@@ -1,6 +1,5 @@
 rules = [
   ProcedureSyntax,
-  RemoveUnused,
   OrganizeImports
 ]
 

--- a/src/main/g8/application/src/main/scala/$package__packaged$/api/Server.scala
+++ b/src/main/g8/application/src/main/scala/$package__packaged$/api/Server.scala
@@ -1,10 +1,11 @@
 package $package$.api
 
-import cats.effect._
-import cats.implicits._
 import $package$.api.commands.{ApiConfig, Commands, DatabaseConfig}
 import $package$.api.endpoints.UserEndpoints
 import $package$.api.services.UsersService
+
+import cats.effect._
+import cats.implicits._
 import doobie.hikari.HikariTransactor
 import doobie.util.ExecutionContexts
 import org.http4s.implicits._

--- a/src/main/g8/application/src/main/scala/$package__packaged$/api/commands/ApiOptions.scala
+++ b/src/main/g8/application/src/main/scala/$package__packaged$/api/commands/ApiOptions.scala
@@ -2,8 +2,8 @@ package $package$.api.commands
 
 import cats.implicits._
 import com.monovore.decline.Opts
-import eu.timepit.refined.types.numeric.PosInt
 import com.monovore.decline.refined._
+import eu.timepit.refined.types.numeric.PosInt
 
 trait ApiOptions {
 

--- a/src/main/g8/application/src/main/scala/$package__packaged$/api/commands/Commands.scala
+++ b/src/main/g8/application/src/main/scala/$package__packaged$/api/commands/Commands.scala
@@ -1,9 +1,9 @@
 package $package$.api.commands
 
 import cats.effect.{ContextShift, ExitCode, IO}
+import cats.implicits._
 import com.monovore.decline._
 import org.flywaydb.core.Flyway
-import cats.implicits._
 
 object Commands {
 

--- a/src/main/g8/application/src/main/scala/$package__packaged$/api/commands/DatabaseOptions.scala
+++ b/src/main/g8/application/src/main/scala/$package__packaged$/api/commands/DatabaseOptions.scala
@@ -1,15 +1,14 @@
 package $package$.api.commands
 
-import cats.implicits._
-import com.monovore.decline.Opts
 import cats.effect._
-import doobie.util.transactor.Transactor
-import doobie.implicits._
-import com.lightbend.emoji.ShortCodes.Implicits._
+import cats.implicits._
 import com.lightbend.emoji.ShortCodes.Defaults._
-import com.monovore.decline._
-import eu.timepit.refined.types.numeric._
+import com.lightbend.emoji.ShortCodes.Implicits._
+import com.monovore.decline.Opts
 import com.monovore.decline.refined._
+import doobie.implicits._
+import doobie.util.transactor.Transactor
+import eu.timepit.refined.types.numeric._
 
 import scala.util.Try
 

--- a/src/main/g8/application/src/main/scala/$package__packaged$/api/endpoints/UserEndpoints.scala
+++ b/src/main/g8/application/src/main/scala/$package__packaged$/api/endpoints/UserEndpoints.scala
@@ -1,10 +1,11 @@
 package $package$.api.endpoints
 
-import java.util.UUID
-
 import $package$.datamodel.User
+
 import sttp.tapir._
 import sttp.tapir.json.circe._
+
+import java.util.UUID
 
 object UserEndpoints {
 

--- a/src/main/g8/application/src/main/scala/$package__packaged$/api/services/UserService.scala
+++ b/src/main/g8/application/src/main/scala/$package__packaged$/api/services/UserService.scala
@@ -1,19 +1,20 @@
 package $package$.api.services
 
-import java.util.UUID
-
-import cats.effect._
-import cats.implicits._
 import $package$.api.endpoints.UserEndpoints
 import $package$.database.UserDao
 import $package$.datamodel.User
-import doobie.util.transactor.Transactor
+
+import cats.effect._
+import cats.implicits._
 import doobie._
 import doobie.implicits._
+import doobie.util.transactor.Transactor
+import eu.timepit.refined.auto._
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import sttp.tapir.server.http4s._
-import eu.timepit.refined.auto._
+
+import java.util.UUID
 
 class UsersService[F[_]: Sync](xa: Transactor[F])(
     implicit contextShift: ContextShift[F]

--- a/src/main/g8/application/src/main/scala/$package__packaged$/database/UserDao.scala
+++ b/src/main/g8/application/src/main/scala/$package__packaged$/database/UserDao.scala
@@ -1,13 +1,14 @@
 package $package$.database
 
-import java.util.UUID
-
-import $package$.datamodel.User
 import $package$.database.util.Dao
-import doobie.util.fragment.Fragment
+import $package$.datamodel.User
+
 import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
+import doobie.util.fragment.Fragment
+
+import java.util.UUID
 
 object UserDao extends Dao[User] {
   val tableName: String = "users"

--- a/src/main/g8/application/src/main/scala/$package__packaged$/database/util/Dao.scala
+++ b/src/main/g8/application/src/main/scala/$package__packaged$/database/util/Dao.scala
@@ -1,11 +1,11 @@
 package $package$.database.util
 
-import java.util.UUID
-
 import doobie.implicits._
+import doobie.postgres.implicits._
 import doobie.util.{Read, Write}
 import doobie.{LogHandler => _, _}
-import doobie.postgres.implicits._
+
+import java.util.UUID
 
 /**
   * This is abstraction over the listing of arbitrary types from the DB with filters/pagination

--- a/src/main/g8/application/src/main/scala/$package__packaged$/datamodel/User.scala
+++ b/src/main/g8/application/src/main/scala/$package__packaged$/datamodel/User.scala
@@ -1,9 +1,9 @@
 package $package$.datamodel
 
-import java.util.UUID
-
 import io.circe._
 import io.circe.generic.semiauto._
+
+import java.util.UUID
 
 case class User(id: UUID, email: String)
 

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -59,7 +59,7 @@ val tapirSwaggerUIHttp4s = "com.softwaremill.sttp.tapir" %% "tapir-swagger-ui-ht
 
 // Enable a basic import sorter -- rules are defined in .scalafix.conf
 ThisBuild / scalafixDependencies +=
-  "com.nequissimus" %% "sort-imports" % "0.5.4"
+  "com.github.liancheng" %% "organize-imports" % "0.4.3"
 
 lazy val settings = Seq(
   organization := "$organization$",


### PR DESCRIPTION
## Overview

Swaps out [`sort-imports`](https://github.com/NeQuissimus/sort-imports) in our scalafix config in favor of [`organize-imports`](https://github.com/liancheng/scalafix-organize-imports).

We already have import order linting configured via `sort-imports`, but per [this comment](https://github.com/azavea/azavea.g8/issues/4#issuecomment-635970870) in #4, we've expressed interest in using `organize-imports` instead.

After reviewing the features and documentation for `organize-imports`, I agree that it appears to be the more robust choice. I wouldn't feel a strong need to migrate projects already using `sort-imports`, but the migration path would be simple if we chose to do so.

Closes #4 

### Notes

I was testing this by creating a new scaffolded project and saw that there are some import order errors present in the freshly created project. Looks like we fixed those issues manually in downstream projects derived from this template. I've resolved those errors to make this PR easier to test.

## Testing Instructions

- From this PR branch, scaffold an app with `sbt new file:///path/to/local/azavea.g8` and accept the defaults.
- Run linting in the scaffolded app with `sbt "scalafix --check"`. The linting should pass.
- Swap the order of one of the imports in the app and run `sbt "scalafix --check"` again. The linting should fail.