### PR TITLE
Add support for automatically merging Scala Steward PRs

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -40,6 +40,7 @@ jobs:
             --default-api-port=8080 \
             --default-db-port=5432
           cd ci && sbt ";bloopInstall; scalafmt; scalafmtSbt; scalafix --check"
+
   merge-dependabot:
     needs:
       - build
@@ -49,6 +50,7 @@ jobs:
         with:
           GITHUB_LOGIN: "dependabot[bot]"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   merge-dependabot-preview:
     needs:
       - build
@@ -57,4 +59,14 @@ jobs:
       - uses: ridedott/merge-me-action@v1.8.53
         with:
           GITHUB_LOGIN: "dependabot-preview[bot]"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  merge-scala-steward:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ridedott/merge-me-action@v1.8.53
+        with:
+          GITHUB_LOGIN: "azavea-bot"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When the build for a PR associated with [our internal Scala Steward instance](https://github.com/azavea/scala-steward) passes, automatically merge it.

Fixes https://github.com/azavea/azavea.g8/issues/23

---

### Notes

Targeting the `azavea.g8` repository was useful in ensuring the the internal Scala Steward instance works. We may or may not want to use it for this repository though, because it is open source (e.g., there may be a publicity benefit to using the public Scala Steward instance instead).

### Testing

Unfortunately, I don't think I can effectively test this without making these changes available on the `master` branch. But, after they are, rebasing https://github.com/azavea/azavea.g8/pull/32 and https://github.com/azavea/azavea.g8/pull/33 is expected to lead to automatic merges _after_ the builds complete successfully.