### PR TITLE
Don't needlessly log at error level

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -146,7 +146,8 @@ lazy val settings = Seq(
   run / fork := true,
   shellPrompt := { s =>
     Project.extract(s).currentProject.id + " > "
-  }
+  },
+  outputStrategy := Some(StdoutOutput)
 )
 
 lazy val dependencies = Seq(


### PR DESCRIPTION
This PR sets an `outputStrategy` so we don't needlessly log at the error level. Here's some nice sample output:

```
[info] running (fork) com.azavea.quickstart.api.Server serve
[ioapp-compute-12] INFO org.http4s.blaze.channel.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:8080
[ioapp-compute-12] INFO org.http4s.server.blaze.BlazeServerBuilder - 
  _   _   _        _ _
 | |_| |_| |_ _ __| | | ___
 | ' \  _|  _| '_ \_  _(_-<
 |_||_\__|\__| .__/ |_|/__/
             |_|
[ioapp-compute-12] INFO org.http4s.server.blaze.BlazeServerBuilder - http4s v0.21.5 on blaze v0.14.12 started at http://[::]:8080/
```

Closes #57 